### PR TITLE
Fix duplicate muscle groups from seed data typos

### DIFF
--- a/Sources/WorkoutTrackerApp/Seed/SeedCatalog.swift
+++ b/Sources/WorkoutTrackerApp/Seed/SeedCatalog.swift
@@ -16,7 +16,7 @@ struct SeedExercise {
 }
 
 enum SeedCatalog {
-    static let seedVersion = 2
+    static let seedVersion = 3
 
     static let defaultWeeklySetGoal = 85
 
@@ -166,7 +166,7 @@ enum SeedCatalog {
             legacyID: 10,
             name: "Tricep rope",
             muscleGroup: "Triceps",
-            secondaryMuscleGroups: ["Core"],
+            secondaryMuscleGroups: ["Abs"],
             notes: "",
             weekdayIndex: nil,
             customSlot: nil,
@@ -208,7 +208,7 @@ enum SeedCatalog {
             legacyID: 13,
             name: "Machine/dumbell flies",
             muscleGroup: "Chest",
-            secondaryMuscleGroups: ["Bisceps"],
+            secondaryMuscleGroups: ["Biceps"],
             notes: "",
             weekdayIndex: nil,
             customSlot: nil,

--- a/Sources/WorkoutTrackerApp/Services/WorkoutRepository.swift
+++ b/Sources/WorkoutTrackerApp/Services/WorkoutRepository.swift
@@ -1094,6 +1094,7 @@ final class WorkoutRepository: ObservableObject {
             }
 
             seedLibraryDataIfNeeded()
+            migratePhantomMuscleGroups()
             settings.seedVersion = SeedCatalog.seedVersion
             ensureDefaultGoalCard()
             try context.save()
@@ -1203,6 +1204,42 @@ final class WorkoutRepository: ObservableObject {
             )
             context.insert(item)
         }
+    }
+
+    private func migratePhantomMuscleGroups() {
+        let renames: [String: String] = [
+            "Bisceps": "Biceps",
+            "Core": "Abs"
+        ]
+
+        for (oldName, newName) in renames {
+            let oldNorm = normalizeGroupName(oldName)
+
+            // Fix secondaryMuscleGroupsRaw on all entity types that store it
+            for exercise in exerciseCatalog where exercise.secondaryMuscleGroupsRaw.contains(oldName) {
+                exercise.secondaryMuscleGroupsRaw = exercise.secondaryMuscleGroupsRaw
+                    .replacingOccurrences(of: oldName, with: newName)
+            }
+            for item in templateExercises where item.secondaryMuscleGroupsRaw.contains(oldName) {
+                item.secondaryMuscleGroupsRaw = item.secondaryMuscleGroupsRaw
+                    .replacingOccurrences(of: oldName, with: newName)
+            }
+            for weekly in weeklyExercises where weekly.secondaryMuscleGroupsRaw.contains(oldName) {
+                weekly.secondaryMuscleGroupsRaw = weekly.secondaryMuscleGroupsRaw
+                    .replacingOccurrences(of: oldName, with: newName)
+            }
+            for log in completionLogs where log.secondaryMuscleGroupsRaw.contains(oldName) {
+                log.secondaryMuscleGroupsRaw = log.secondaryMuscleGroupsRaw
+                    .replacingOccurrences(of: oldName, with: newName)
+            }
+
+            // Delete the phantom MuscleGroupEntity
+            for group in muscleGroups where normalizeGroupName(group.name) == oldNorm {
+                context.delete(group)
+            }
+        }
+
+        saveAndRefresh()
     }
 
     private func migrateToSectionHeadersIfNeeded() {


### PR DESCRIPTION
## Changes

- **SeedCatalog.swift**: Fixed typos in seed exercise data:
  - Changed "Core" to "Abs" in Tricep rope secondary muscle groups
  - Changed "Bisceps" to "Biceps" in Machine/dumbell flies secondary muscle groups
  - Bumped seed version from 2 to 3

- **WorkoutRepository.swift**: Added migration function to clean up phantom muscle groups:
  - New `migratePhantomMuscleGroups()` method corrects invalid muscle group names in all relevant entities (exercise catalog, templates, weekly exercises, and completion logs)
  - Deletes orphaned MuscleGroupEntity records that resulted from the typos
  - Called during seed data initialization to ensure data consistency