### PR TITLE
Accept comma as decimal separator in weight inputs

### DIFF
--- a/Sources/WorkoutTrackerApp/Utils/Formatting.swift
+++ b/Sources/WorkoutTrackerApp/Utils/Formatting.swift
@@ -36,6 +36,7 @@ enum Formatting {
         }
 
         var value = trimmed
+            .replacingOccurrences(of: ",", with: ".")
             .replacingOccurrences(of: "kg", with: "")
             .replacingOccurrences(of: "lb", with: "")
 

--- a/Sources/WorkoutTrackerApp/Views/Tracking/TrackingView.swift
+++ b/Sources/WorkoutTrackerApp/Views/Tracking/TrackingView.swift
@@ -337,6 +337,11 @@ private struct AddWeighInSheet: View {
     @State private var weight: String = ""
     @State private var bodyFat: String = ""
 
+    /// Accept both comma and dot as decimal separator.
+    private func parseDecimal(_ text: String) -> Double? {
+        Double(text.replacingOccurrences(of: ",", with: "."))
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -361,14 +366,14 @@ private struct AddWeighInSheet: View {
                         isPresented = false
                         Haptics.success()
                     }
-                    .disabled(Double(weight) == nil)
+                    .disabled(parseDecimal(weight) == nil)
                 }
             }
         }
     }
 
     private func save() {
-        guard let rawWeight = Double(weight) else { return }
+        guard let rawWeight = parseDecimal(weight) else { return }
 
         let kgWeight: Double
         switch repository.unitSystem {
@@ -380,7 +385,7 @@ private struct AddWeighInSheet: View {
 
         repository.addBodyMetric(kind: .scaleWeight, value: kgWeight)
 
-        if let bf = Double(bodyFat), bf > 0 {
+        if let bf = parseDecimal(bodyFat), bf > 0 {
             repository.addBodyMetric(kind: .visualBodyFat, value: bf)
         }
     }


### PR DESCRIPTION
## Changes

- Added comma-to-dot replacement in `Formatting.swift` for weight parsing
- Added `parseDecimal()` helper function in `AddWeighInSheet` to normalize decimal separators
- Updated weight and body fat input validation to use the new parser

This allows users to input weights using either comma or dot as decimal separator, improving UX for locales that use comma as the decimal separator.